### PR TITLE
fix: use `json` option in NATS client

### DIFF
--- a/src/nats-pubsub.ts
+++ b/src/nats-pubsub.ts
@@ -2,8 +2,10 @@ import { PubSubAsyncIterator } from './pubsub-async-iterator'
 import { PubSubEngine } from 'graphql-subscriptions'
 import * as nats from 'nats'
 
+const defaultOptions = { json: true }
 export class NatsPubSub implements PubSubEngine {
   private nats: nats.Client
+  private json: Boolean
 
   constructor(options: nats.ClientOpts & { nc?: nats.Client }) {
     if (options.nc) {
@@ -11,14 +13,18 @@ export class NatsPubSub implements PubSubEngine {
     } else {
       this.nats = nats.connect(options)
     }
+    
+    this.json = this.nats.options.json === true
   }
 
   public async publish(subject: string, payload: any): Promise<void> {
-    return await this.nats.publish(subject, JSON.stringify(payload))
+    if (!this.json) payload = JSON.stringify(payload)
+    return await this.nats.publish(subject, payload)
   }
 
   public async subscribe(subject: string, onMessage: Function): Promise<number> {
-    return await this.nats.subscribe(subject, (event: string) => onMessage(JSON.parse(event)))
+    if (!this.json) onMessage = (event: string) => onMessage(JSON.parse(event))
+    return await this.nats.subscribe(subject, onMessage)
   }
 
   public unsubscribe(sid: number) {


### PR DESCRIPTION
Allows users to configure non-JSON messages,
Fixes the double parsing/formatting when using the `json` option to configure this library.

Maintains backwards compatibility for both users passing `nc` and client options.